### PR TITLE
xcframeworks improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,9 +280,17 @@ Like `build_settings` but per pod. Pod name can also refer to subspec.
 
 Specify which build system to use to compile frameworks. Either `Legacy` (standard build system) or `Latest` (new build system). Default value: `Latest`.
 
-#### `build_xcframeworks`
+#### `build_xcframeworks_all`
 
-Specify if PodBuilder will build .xcframeworks. Will enable `library_evolution_support`. Default value: false
+Specify if PodBuilder should build all pods as .xcframeworks. Will enable `library_evolution_support`. Default value: false
+
+#### `build_xcframeworks_exclude`
+
+Specify which pods PodBuilder should NOT be built as .xcframeworks when `build_xcframeworks_all` is true. Default value: []
+
+#### `build_xcframeworks_include`
+
+Specify which pods PodBuilder should be built as .xcframeworks. Will enable `library_evolution_support`. Default value: []
 
 #### `library_evolution_support`
 

--- a/lib/pod_builder/command/build.rb
+++ b/lib/pod_builder/command/build.rb
@@ -71,6 +71,12 @@ module PodBuilder
 
         check_dependencies_build_configurations(all_buildable_items)
 
+        # When building mixed framwork/xcframeworks pods xcframeworks should be built last 
+        # so that the .xcframework overwrite the .framwork if the same pod needs to be built
+        # in both ways. 
+        # For example we might have configured to build onlt PodA as xcframework, another pod
+        # PodB has a dependency to PodA. When Building PodB, PodA gets rebuilt as .framework
+        # but then PodA gets rebuilt again as .xcframework overwriting the .framework.
         podfiles_items = [pods_to_build_debug] + [pods_to_build_release] + [pods_to_build_debug_xcframework] + [pods_to_build_release_xcframework]
 
         install_using_frameworks = Podfile::install_using_frameworks(analyzer)

--- a/lib/pod_builder/command/build.rb
+++ b/lib/pod_builder/command/build.rb
@@ -63,9 +63,15 @@ module PodBuilder
         pods_to_build_debug = pods_to_build.select { |x| x.build_configuration == "debug" }
         pods_to_build_release = pods_to_build - pods_to_build_debug
 
+        pods_to_build_debug_xcframework = pods_to_build_debug.select { |x| x.build_xcframework }
+        pods_to_build_debug -= pods_to_build_debug_xcframework
+
+        pods_to_build_release_xcframework = pods_to_build_release.select { |x| x.build_xcframework }
+        pods_to_build_release -= pods_to_build_release_xcframework
+
         check_dependencies_build_configurations(all_buildable_items)
 
-        podfiles_items = [pods_to_build_debug] + [pods_to_build_release]
+        podfiles_items = [pods_to_build_debug] + [pods_to_build_release] + [pods_to_build_debug_xcframework] + [pods_to_build_release_xcframework]
 
         install_using_frameworks = Podfile::install_using_frameworks(analyzer)
         if Configuration.react_native_project
@@ -86,7 +92,8 @@ module PodBuilder
           build_configuration = podfile_items.map(&:build_configuration).uniq.first
           
           podfile_items = podfile_items.map { |t| t.recursive_dependencies(all_buildable_items) }.flatten.uniq
-          podfile_content = Podfile.from_podfile_items(podfile_items, analyzer, build_configuration, install_using_frameworks, build_catalyst, Configuration.build_xcframeworks)
+
+          podfile_content = Podfile.from_podfile_items(podfile_items, analyzer, build_configuration, install_using_frameworks, build_catalyst, podfile_items.first.build_xcframework)
           
           install_result += Install.podfile(podfile_content, podfile_items, podfile_items.first.build_configuration)          
           

--- a/lib/pod_builder/configuration.rb
+++ b/lib/pod_builder/configuration.rb
@@ -292,6 +292,11 @@ module PodBuilder
           puts "PodBuilder.json contains '#{pod}' both in `force_prebuild_pods` and `skip_pods`. Will force prebuilding.".yellow
         end
       end
+      if Configuration.build_xcframeworks_all
+        raise "Invalid PodBuilder.json configuration: 'build_xcframeworks_all' is true and 'build_xcframeworks_include' is not empty" if Configuration.build_xcframeworks_include.count > 0
+      else
+        raise "Invalid PodBuilder.json configuration: 'build_xcframeworks_all' is false and 'build_xcframeworks_exclude' is not empty" if Configuration.build_xcframeworks_exclude.count > 0
+      end
     end
     
     def self.config_path

--- a/lib/pod_builder/configuration.rb
+++ b/lib/pod_builder/configuration.rb
@@ -39,18 +39,10 @@ module PodBuilder
         "ENABLE_BITCODE": "NO"
       }
     }.freeze
-    DEFAULT_SKIP_PODS = ["GoogleMaps", "React-RCTFabric", "React-Core", "React-CoreModules"] # Not including React-RCTNetwork might loose some debug warnings
-
-    DEFAULT_FORCE_PREBUILD_PODS = []
-    DEFAULT_BUILD_SYSTEM = "Latest".freeze # either Latest (New build system) or Legacy (Standard build system)
-    DEFAULT_LIBRARY_EVOLUTION_SUPPORT = false
-    DEFAULT_PLATFORMS = ["iphoneos", "iphonesimulator", "appletvos", "appletvsimulator"].freeze
-    DEFAULT_BUILD_USING_REPO_PATHS = false
     
     private_constant :DEFAULT_BUILD_SETTINGS
     private_constant :DEFAULT_BUILD_SETTINGS_OVERRIDES
-    private_constant :DEFAULT_BUILD_SYSTEM
-    private_constant :DEFAULT_LIBRARY_EVOLUTION_SUPPORT
+    private_constant :DEFAULT_SPEC_OVERRIDE
     
     class <<self      
       attr_accessor :allow_building_development_pods
@@ -84,17 +76,18 @@ module PodBuilder
       attr_accessor :build_xcframeworks_include
       attr_accessor :build_xcframeworks_exclude
     end
-    
-    @allow_building_development_pods = false
+
     @build_settings = DEFAULT_BUILD_SETTINGS
     @build_settings_overrides = DEFAULT_BUILD_SETTINGS_OVERRIDES
-    @build_system = DEFAULT_BUILD_SYSTEM
-    @library_evolution_support = DEFAULT_LIBRARY_EVOLUTION_SUPPORT
-    @base_path = "PodBuilder" # Not nice. This value is used only for initial initization. Once config is loaded it will be an absolute path. FIXME
     @spec_overrides = DEFAULT_SPEC_OVERRIDE
+
+    @allow_building_development_pods = false
+    @build_system = "Latest".freeze # either Latest (New build system) or Legacy (Standard build system)
+    @library_evolution_support = false
+    @base_path = "PodBuilder" # Not nice. This value is used only for initial initization. Once config is loaded it will be an absolute path. FIXME
     @skip_licenses = []
-    @skip_pods = DEFAULT_SKIP_PODS
-    @force_prebuild_pods = DEFAULT_FORCE_PREBUILD_PODS
+    @skip_pods = ["GoogleMaps", "React-RCTFabric", "React-Core", "React-CoreModules"] # Not including React-RCTNetwork might loose some debug warnings
+    @force_prebuild_pods = []
     @license_filename = "Pods-acknowledgements"
     @development_pods_paths = []
     @build_base_path = "/tmp/pod_builder".freeze
@@ -111,8 +104,8 @@ module PodBuilder
     @use_bundler = false
     @deterministic_build = false
 
-    @supported_platforms = DEFAULT_PLATFORMS
-    @build_using_repo_paths = DEFAULT_BUILD_USING_REPO_PATHS
+    @supported_platforms = ["iphoneos", "iphonesimulator", "appletvos", "appletvsimulator"].freeze
+    @build_using_repo_paths = false
     @react_native_project = false
 
     @build_xcframeworks_all = false
@@ -236,7 +229,7 @@ module PodBuilder
             Configuration.build_xcframeworks_exclude = value
           end
         end
-        
+
         Configuration.build_settings.freeze
 
         sanity_check()

--- a/lib/pod_builder/configuration.rb
+++ b/lib/pod_builder/configuration.rb
@@ -46,7 +46,6 @@ module PodBuilder
     DEFAULT_LIBRARY_EVOLUTION_SUPPORT = false
     DEFAULT_PLATFORMS = ["iphoneos", "iphonesimulator", "appletvos", "appletvsimulator"].freeze
     DEFAULT_BUILD_USING_REPO_PATHS = false
-    DEFAULT_BUILD_XCFRAMEWORKS = false
     
     private_constant :DEFAULT_BUILD_SETTINGS
     private_constant :DEFAULT_BUILD_SETTINGS_OVERRIDES
@@ -81,7 +80,9 @@ module PodBuilder
       attr_accessor :build_using_repo_paths
       attr_accessor :react_native_project
       attr_accessor :lldbinit_name
-      attr_accessor :build_xcframeworks
+      attr_accessor :build_xcframeworks_all
+      attr_accessor :build_xcframeworks_include
+      attr_accessor :build_xcframeworks_exclude
     end
     
     @allow_building_development_pods = false
@@ -114,7 +115,9 @@ module PodBuilder
     @build_using_repo_paths = DEFAULT_BUILD_USING_REPO_PATHS
     @react_native_project = false
 
-    @build_xcframeworks = DEFAULT_BUILD_XCFRAMEWORKS
+    @build_xcframeworks_all = false
+    @build_xcframeworks_include = []
+    @build_xcframeworks_exclude = []
     
     def self.check_inited
       raise "\n\nNot inited, run `pod_builder init`\n".red if podbuilder_path.nil?
@@ -218,9 +221,19 @@ module PodBuilder
             Configuration.react_native_project = value
           end
         end
-        if value = json["build_xcframeworks"]
+        if value = json["build_xcframeworks_all"]
           if [TrueClass, FalseClass].include?(value.class)
-            Configuration.build_xcframeworks = value
+            Configuration.build_xcframeworks_all = value
+          end
+        end
+        if value = json["build_xcframeworks_include"]
+          if value.is_a?(Array)
+            Configuration.build_xcframeworks_include = value
+          end
+        end
+        if value = json["build_xcframeworks_exclude"]
+          if value.is_a?(Array)
+            Configuration.build_xcframeworks_exclude = value
           end
         end
         

--- a/lib/pod_builder/podfile.rb
+++ b/lib/pod_builder/podfile.rb
@@ -60,11 +60,10 @@ module PodBuilder
 
         if Configuration.build_system == "Legacy"
           build_settings["BUILD_LIBRARY_FOR_DISTRIBUTION"] = "NO"
-          raise "\n\nCan't enable library evolution support with legacy build system!".red if Configuration.library_evolution_support
-        elsif Configuration.library_evolution_support
+        elsif Configuration.library_evolution_support || item.build_xcframework
           build_settings["BUILD_LIBRARY_FOR_DISTRIBUTION"] = "YES"
         end
-        if Configuration.build_xcframeworks
+        if item.build_xcframework
           build_settings["BUILD_LIBRARY_FOR_DISTRIBUTION"] = "YES"
         end
 

--- a/lib/pod_builder/podfile_item.rb
+++ b/lib/pod_builder/podfile_item.rb
@@ -134,6 +134,10 @@ module PodBuilder
     # @return [Bool] Defines module
     #
     attr_accessor :defines_module
+
+    # @return [Bool] Should build as xcframework
+    #
+    attr_accessor :build_xcframework
     
     # Initialize a new instance
     #
@@ -235,6 +239,13 @@ module PodBuilder
       @source = spec.root.attributes_hash.fetch("source", { "git"=>"https://github.com/Subito-it/PodBuilder.git" })
       @authors = spec.root.attributes_hash.fetch("authors", {"PodBuilder"=>"pod@podbuilder.com"})
       @homepage = spec.root.attributes_hash.fetch("homepage", "https://github.com/Subito-it/PodBuilder")
+
+      if Configuration.build_xcframeworks_all
+        build_as_xcframework = !Configuration.build_xcframeworks_exclude.include?(@root_name)
+      else
+        build_as_xcframework = Configuration.build_xcframeworks_include.include?(@root_name)
+      end
+      @build_xcframework = build_as_xcframework
     end
 
     def pod_specification(all_poditems, parent_spec = nil)

--- a/lib/pod_builder/podfile_item.rb
+++ b/lib/pod_builder/podfile_item.rb
@@ -103,27 +103,27 @@ module PodBuilder
     #
     attr_accessor :libraries
 
-    # @return [String] source_files
+    # @return [String] Source_files
     #
     attr_accessor :source_files
 
-    # @return [String] license
+    # @return [String] License
     #
     attr_accessor :license
 
-    # @return [String] summary
+    # @return [String] Summary
     #
     attr_accessor :summary
 
-    # @return [Hash] source
+    # @return [Hash] Source
     #
     attr_accessor :source
 
-    # @return [Hash] authors
+    # @return [Hash] Authors
     #
     attr_accessor :authors
 
-    # @return [String] homepage
+    # @return [String] Homepage
     #
     attr_accessor :homepage
 


### PR DESCRIPTION
This PR adds support to selectively build pods as xcframework. This can be useful to rebuild just the pods that are needed for a specific target, like for example UI targets which do not support amr64 exclusion.

Additionally there's a fix where build configuration was not passed when building xcframeworks.