### PR TITLE
Added new install_sources command option

### DIFF
--- a/exe/pod_builder
+++ b/exe/pod_builder
@@ -248,6 +248,9 @@ Usage:
 
 Options:
 "       
+        opts.on("-p", "--designate-pods", "Designate pods to download") do |o|
+          OPTIONS[:designate_pods] = o
+        end
         opts.on("-s", "--no-stdin", "Never request interaction with sdtin (e.g. in CI environment)") do |o|
           OPTIONS[:no_stdin_available] = o
         end

--- a/exe/pod_builder
+++ b/exe/pod_builder
@@ -242,14 +242,14 @@ Options:
         opts.banner = "
 Usage:
         
-    $ pod_builder install_sources
+    $ pod_builder install_sources [OPTIONS] <PODNAME...>
 
       Install source of prebuilt pods to be able to step into and debug prebuilt's code.
 
 Options:
 "       
-        opts.on("-p", "--designate-pods", "Designate pods to download") do |o|
-          OPTIONS[:designate_pods] = o
+        opts.on("-a", "--all", "Install all available sources") do |o|
+          OPTIONS[:all] = o
         end
         opts.on("-s", "--no-stdin", "Never request interaction with sdtin (e.g. in CI environment)") do |o|
           OPTIONS[:no_stdin_available] = o

--- a/lib/pod_builder/command/install_sources.rb
+++ b/lib/pod_builder/command/install_sources.rb
@@ -11,6 +11,8 @@ module PodBuilder
 
         PodBuilder::prepare_basepath
 
+        argument_pods = OPTIONS.has_key?(:designate_pods) ? ARGV.dup : []
+
         install_update_repo = OPTIONS.fetch(:update_repos, true)
         installer, analyzer = Analyze.installer_at(PodBuilder::basepath, install_update_repo)
         podfile_items = Analyze.podfile_items(installer, analyzer).select { |x| !x.is_prebuilt }
@@ -21,6 +23,7 @@ module PodBuilder
         
         framework_files.each do |path|
           rel_path = Pathname.new(path).relative_path_from(Pathname.new(base_path)).to_s
+          next if OPTIONS.has_key?(:designate_pods) && !argument_pods.include?(rel_path.sub(/\/.*/m, ""))
 
           if podfile_spec = podfile_items.detect { |x| "#{x.root_name}/#{x.prebuilt_rel_path}" == rel_path }
             update_repo(podfile_spec)

--- a/lib/pod_builder/command/install_sources.rb
+++ b/lib/pod_builder/command/install_sources.rb
@@ -11,7 +11,7 @@ module PodBuilder
 
         PodBuilder::prepare_basepath
 
-        argument_pods = OPTIONS.has_key?(:all) ? [] : ARGV.dup
+        argument_pods = ARGV.dup
 
         install_update_repo = OPTIONS.fetch(:update_repos, true)
         installer, analyzer = Analyze.installer_at(PodBuilder::basepath, install_update_repo)
@@ -22,10 +22,9 @@ module PodBuilder
         framework_files = Dir.glob("#{base_path}/**/*.framework")
         
         framework_files.each do |path|
-          rel_path = Pathname.new(path).relative_path_from(Pathname.new(base_path)).to_s
-          next if !OPTIONS.has_key?(:all) && !argument_pods.include?(rel_path.sub(/\/.*/m, ""))
+          next if !OPTIONS.has_key?(:all) && !argument_pods.include?(File.basename(path, ".*"))
 
-          if podfile_spec = podfile_items.detect { |x| "#{x.root_name}/#{x.prebuilt_rel_path}" == rel_path }
+          if podfile_spec = podfile_items.detect { |x| x.root_name == File.basename(path, ".*") }
             update_repo(podfile_spec)
           end
         end

--- a/lib/pod_builder/command/install_sources.rb
+++ b/lib/pod_builder/command/install_sources.rb
@@ -11,7 +11,7 @@ module PodBuilder
 
         PodBuilder::prepare_basepath
 
-        argument_pods = OPTIONS.has_key?(:designate_pods) ? ARGV.dup : []
+        argument_pods = OPTIONS.has_key?(:all) ? [] : ARGV.dup
 
         install_update_repo = OPTIONS.fetch(:update_repos, true)
         installer, analyzer = Analyze.installer_at(PodBuilder::basepath, install_update_repo)
@@ -23,7 +23,7 @@ module PodBuilder
         
         framework_files.each do |path|
           rel_path = Pathname.new(path).relative_path_from(Pathname.new(base_path)).to_s
-          next if OPTIONS.has_key?(:designate_pods) && !argument_pods.include?(rel_path.sub(/\/.*/m, ""))
+          next if !OPTIONS.has_key?(:all) && !argument_pods.include?(rel_path.sub(/\/.*/m, ""))
 
           if podfile_spec = podfile_items.detect { |x| "#{x.root_name}/#{x.prebuilt_rel_path}" == rel_path }
             update_repo(podfile_spec)


### PR DESCRIPTION
## Overview
 We can download the sources of all pre-built pod libraries by running the `install_sources` command. However, there is no need to download all the sources if you only want the sources of a specific pod library.
  Therefore, I made it possible to download only the pod libraries that we need by designating the pod libraries with options.

## What we have done
- We added `-p, --designate-pods` option to `install_sources` command.
  - How to execute: `pod_builder install_sources --designate-pods PodA PodB ...`
- Added a process to get the argument when `designate_pods` option is enabled.
- Added a process to skip cloning when the `designate_pods` option is enabled and a library is not designated.