### PR TITLE
Fix matching of prebuilt items and specs

### DIFF
--- a/lib/pod_builder/rome/post_install.rb
+++ b/lib/pod_builder/rome/post_install.rb
@@ -391,7 +391,7 @@ Pod::HooksManager.register("podbuilder-rome", :post_install) do |installer_conte
       next if built_item_paths.count == 0
 
       module_name = File.basename(built_item_paths.first, ".*")
-      spec = specs.detect { |t| t.module_name == module_name }
+      spec = specs.detect { |t| t.module_name == module_name && t.parent.nil? }
 
       # There seems to be a potential bug in CocoaPods-Core (https://github.com/CocoaPods/Core/issues/730)
       if spec.nil?


### PR DESCRIPTION
This PR fixes the matching of prebuilt items and their corresponding spec during the post-install phase.

Let's consider the following scenario:
- A `Foo` pod produces the `Foo.xcframework` built item.
- An unrelated `Bar` pod contains the `Foo` subspec, and produces the `Bar.xcframework` built item.
- `Pod::Specification::module_name` returns `Foo` for both the `Bar/Foo` and `Foo` specs.

When looking up the spec for the `Foo.xcframework` built item, the previous logic would match `Bar/Foo` first. This leads to the following:
- `Foo.xcframework` is copied inside the `Prebuilt/Bar` folder instead of `Prebuilt/Foo`.
- The `Prebuilt/Foo` folder is left unchanged.

The proposed changes aim to prevent this by making sure that we check name equality between the built item and the spec's `module_name` for root specs first. If no matches are found in root specs, the existing fallback would apply.